### PR TITLE
Remove linting NPM scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,6 @@
     "watch": "slate-tools start --skipFirstDeploy",
     "build": "slate-tools build",
     "deploy": "slate-tools build && slate-tools deploy",
-    "zip": "slate-tools build && slate-tools zip",
-    "lint": "slate-tools lint",
-    "format": "slate-tools format"
+    "zip": "slate-tools build && slate-tools zip"
   }
 }


### PR DESCRIPTION
Because there isn't a `.eslintrc` file present in the root directory, both `yarn lint` and `yarn format` commands will fail. Removing them directly in place of adding a `.eslintrc`.