### PR TITLE
Add font preconnect and preloading

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -14,7 +14,7 @@
       <link rel="preconnect" href="https://fonts.shopifycdn.com" crossorigin>
 
       {% comment %} Preload the base font variant for initial page render {% endcomment %}
-      {{ settings.type_primary_font | font_url | preload_tag: as: 'font' }}
+      {{ settings.type_primary_font | font_url | preload_tag: as: 'font', crossorigin: 'anonymous' }}
     {% endunless %}
 
     {% # Load and preload the critical CSS %}

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -4,6 +4,19 @@
     {% # Inlined CSS Variables %}
     {% render 'css-variables' %}
 
+    {% comment %}
+      Font preloading:
+      1. Preconnect to font CDN for faster connection
+      2. Preload only the critical font variant (base weight)
+      3. Additional variants load on-demand via @font-face
+    {% endcomment %}
+    {% unless settings.type_primary_font.system? %}
+      <link rel="preconnect" href="https://fonts.shopifycdn.com" crossorigin>
+
+      {% comment %} Preload the base font variant for initial page render {% endcomment %}
+      {{ settings.type_primary_font | font_url | preload_tag: as: 'font' }}
+    {% endunless %}
+
     {% # Load and preload the critical CSS %}
     {{ 'critical.css' | asset_url | stylesheet_tag: preload: true }}
 


### PR DESCRIPTION
This PR adds font preloading to improve initial page render performance

* Adds `preconnect` to the fonts CDN
* Uses `preload_tag` for the primary font variant

(Shopify still needs to fix the `crossorigin` bug in `preload_tag` — see #46)

This is the new markup added with this PR on a deployed skeleton theme:

```html
      <link rel="preconnect" href="https://fonts.shopifycdn.com" crossorigin>
      
      
      <link href="//slug.myshopify.com/cdn/fonts/work_sans/worksans_n4.b7973b3d07d0ace13de1b1bea9c45759cdbe12cf.woff2?h1=eG5taWRuLW41LmFjY291bnQubXlzaG9waWZ5LmNvbQ&amp;hmac=f9a9f15cab2f3b8d2aca3dffa1584677c8e3d881c0cea9532487b9246e27f611" as="font" rel="preload">
```