### PR TITLE
Add customer account menu web component

### DIFF
--- a/assets/icon-account.svg
+++ b/assets/icon-account.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" slot="signed-out-avatar">
   <circle cx="10" cy="6.5" r="2.75" stroke="currentColor" stroke-width="var(--icon-stroke-width)" />
   <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"
     stroke-width="var(--icon-stroke-width)"

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -42,6 +42,7 @@
     "input_corner_radius": "Input corner radius",
     "layout_direction": "Layout direction",
     "menu": "Menu",
+    "customer_account_menu": "Customer account menu",
     "padding": "Padding",
     "page_margin": "Page margin",
     "page_width": "Page width",

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -11,7 +11,9 @@
 
   <div class="header__icons">
     {% if shop.customer_accounts_enabled %}
-      {{ 'icon-account.svg' | inline_asset_content | link_to: routes.account_url }}
+      <shopify-account menu="{{ section.settings.customer_account_menu }}">
+        {{ 'icon-account.svg' | inline_asset_content }}
+      </shopify-account>
     {% endif %}
 
     <a href="{{ routes.cart_url }}">
@@ -35,6 +37,9 @@
     position: relative;
     text-decoration: none;
     color: var(--color-foreground);
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
   header a sup {
     position: absolute;
@@ -60,6 +65,12 @@
       "type": "link_list",
       "id": "menu",
       "label": "t:labels.menu"
+    },
+    {
+      "type": "link_list",
+      "id": "customer_account_menu",
+      "label": "t:labels.customer_account_menu",
+      "default": "customer-account-main-menu"
     }
   ]
 }


### PR DESCRIPTION
Adds the new [`<shopify-account>` web component](https://shopify.dev/docs/api/storefront-web-components/components/shopify-account) to the header, replacing the existing account link.