### PR TITLE
chore: update global design tokens to match VTB brand aesthetic

### DIFF
--- a/assets/critical.css
+++ b/assets/critical.css
@@ -74,8 +74,168 @@ p:empty {
 /** Theme styles below */
 body {
   font-family: var(--font-primary--family);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-normal);
+  line-height: var(--line-height-normal);
   background-color: var(--color-background);
   color: var(--color-foreground);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/** Headings */
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-primary--family);
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--line-height-tight);
+  color: var(--color-text-primary);
+}
+
+/** Section headings (e.g. SHOP BY CATEGORY) */
+.section-heading {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--letter-spacing-widest);
+  text-transform: uppercase;
+  color: var(--color-text-primary);
+}
+
+/** Links */
+a {
+  color: inherit;
+  text-decoration: none;
+  transition: color var(--transition-fast);
+}
+
+a:hover {
+  color: var(--color-text-secondary);
+}
+
+/** Buttons – base */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  font-family: var(--font-primary--family);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--letter-spacing-wider);
+  text-transform: uppercase;
+  border: var(--style-border-width) solid transparent;
+  border-radius: var(--style-border-radius-buttons);
+  cursor: pointer;
+  transition:
+    background-color var(--transition-base),
+    color var(--transition-base),
+    border-color var(--transition-base);
+  white-space: nowrap;
+}
+
+/** Buttons – primary (filled / SHOP NOW style) */
+.btn--primary {
+  background-color: var(--color-btn-primary-bg);
+  color: var(--color-btn-primary-text);
+  border-color: var(--color-btn-primary-bg);
+}
+
+.btn--primary:hover {
+  background-color: var(--color-btn-primary-bg-hover);
+  border-color: var(--color-btn-primary-bg-hover);
+  color: var(--color-btn-primary-text);
+}
+
+/** Buttons – secondary (outline / READ MORE style) */
+.btn--secondary {
+  background-color: var(--color-btn-secondary-bg);
+  color: var(--color-btn-secondary-text);
+  border-color: var(--color-btn-secondary-border);
+}
+
+.btn--secondary:hover {
+  background-color: var(--color-btn-secondary-bg-hover);
+  color: var(--color-btn-secondary-text-hover);
+  border-color: var(--color-btn-secondary-bg-hover);
+}
+
+/** Inputs & form fields */
+input[type="text"],
+input[type="email"],
+input[type="search"],
+input[type="password"],
+input[type="tel"],
+textarea {
+  border: var(--style-border-width) solid var(--color-border);
+  border-radius: var(--style-border-radius-inputs);
+  padding: 0.625rem 0.875rem;
+  background-color: var(--color-surface-primary);
+  color: var(--color-text-primary);
+  transition: border-color var(--transition-fast);
+}
+
+input[type="text"]:focus,
+input[type="email"]:focus,
+input[type="search"]:focus,
+input[type="password"]:focus,
+input[type="tel"]:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--color-text-primary);
+}
+
+/** Cards */
+.card {
+  background-color: var(--color-surface-primary);
+  border: var(--style-border-width) solid var(--color-border);
+  border-radius: var(--style-border-radius-cards);
+}
+
+/** Badges */
+.badge {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--letter-spacing-wide);
+  text-transform: uppercase;
+  border-radius: 0;
+}
+
+.badge--new {
+  background-color: var(--color-badge-new);
+  color: var(--color-text-inverted);
+}
+
+.badge--sale {
+  background-color: var(--color-badge-sale);
+  color: var(--color-text-inverted);
+}
+
+/** Pricing */
+.price {
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+.price--sale {
+  color: var(--color-price-sale);
+}
+
+.price--compare {
+  color: var(--color-price-compare);
+  text-decoration: line-through;
+  font-weight: var(--font-weight-normal);
+}
+
+/** Star ratings */
+.star-rating {
+  color: var(--color-star-rating);
+}
+
+/** Dividers */
+hr {
+  border: none;
+  border-top: var(--style-border-width) solid var(--color-border);
 }
 
 /** Section layout utilities */

--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -8,5 +8,12 @@
  * ------------------------------------------------------------
  */
 {
-  "current": {}
+  "current": {
+    "type_primary_font": "work_sans_n4",
+    "max_page_width": "110rem",
+    "min_page_margin": 20,
+    "background_color": "#ffffff",
+    "foreground_color": "#2d2d2d",
+    "input_corner_radius": 0
+  }
 }

--- a/snippets/css-variables.liquid
+++ b/snippets/css-variables.liquid
@@ -6,13 +6,124 @@
   {{ settings.type_primary_font | font_modify: 'style', 'italic' | font_face: font_display: 'swap' }}
 
   :root {
+    /* ── Typography ────────────────────────────────────────────── */
     --font-primary--family: {{ settings.type_primary_font.family }}, {{ settings.type_primary_font.fallback_families }};
     --font-primary--style: {{ settings.type_primary_font.style }};
     --font-primary--weight: {{ settings.type_primary_font.weight }};
+
+    /* ── Layout ────────────────────────────────────────────────── */
     --page-width: {{ settings.max_page_width }};
     --page-margin: {{ settings.min_page_margin }}px;
+
+    /* ── Base colors (from theme settings) ─────────────────────── */
     --color-background: {{ settings.background_color }};
     --color-foreground: {{ settings.foreground_color }};
+
+    /* ── Extended color palette (VTB brand) ─────────────────────── */
+
+    /* Surfaces */
+    --color-surface-primary: #ffffff;
+    --color-surface-secondary: #f9fafb;
+    --color-surface-tertiary: #f3f4f6;
+
+    /* Header / announcement bar */
+    --color-header-bg: #1a2332;
+    --color-header-text: #ffffff;
+    --color-nav-bg: #ffffff;
+    --color-nav-text: #2d2d2d;
+
+    /* Buttons – primary (filled) */
+    --color-btn-primary-bg: #2d2d2d;
+    --color-btn-primary-text: #ffffff;
+    --color-btn-primary-bg-hover: #1a1a1a;
+
+    /* Buttons – secondary (outline) */
+    --color-btn-secondary-bg: transparent;
+    --color-btn-secondary-text: #2d2d2d;
+    --color-btn-secondary-border: #2d2d2d;
+    --color-btn-secondary-bg-hover: #2d2d2d;
+    --color-btn-secondary-text-hover: #ffffff;
+
+    /* Text hierarchy */
+    --color-text-primary: #2d2d2d;
+    --color-text-secondary: #6b7280;
+    --color-text-muted: #9ca3af;
+    --color-text-inverted: #ffffff;
+
+    /* Borders & dividers */
+    --color-border: #e5e7eb;
+    --color-border-strong: #d1d5db;
+
+    /* Feedback / accents */
+    --color-price-sale: #c0392b;
+    --color-price-compare: #9ca3af;
+    --color-star-rating: #f5a623;
+    --color-badge-new: #1a2332;
+    --color-badge-sale: #c0392b;
+
+    /* Footer */
+    --color-footer-bg: #2c3748;
+    --color-footer-text: #e5e7eb;
+    --color-footer-border: #3d4f63;
+    --color-footer-heading: #ffffff;
+    --color-footer-link: #d1d5db;
+    --color-footer-link-hover: #ffffff;
+
+    /* Promotional/announcement strip */
+    --color-promo-bg: #f9fafb;
+    --color-promo-text: #2d2d2d;
+
+    /* ── Borders & shape ────────────────────────────────────────── */
     --style-border-radius-inputs: {{ settings.input_corner_radius }}px;
+    --style-border-radius-buttons: 0px;
+    --style-border-radius-cards: 0px;
+    --style-border-width: 1px;
+
+    /* ── Spacing scale ──────────────────────────────────────────── */
+    --space-1: 0.25rem;
+    --space-2: 0.5rem;
+    --space-3: 0.75rem;
+    --space-4: 1rem;
+    --space-6: 1.5rem;
+    --space-8: 2rem;
+    --space-10: 2.5rem;
+    --space-12: 3rem;
+    --space-16: 4rem;
+
+    /* ── Typography scale ───────────────────────────────────────── */
+    --font-size-xs: 0.75rem;
+    --font-size-sm: 0.875rem;
+    --font-size-base: 1rem;
+    --font-size-lg: 1.125rem;
+    --font-size-xl: 1.25rem;
+    --font-size-2xl: 1.5rem;
+    --font-size-3xl: 1.875rem;
+    --font-size-4xl: 2.25rem;
+
+    --font-weight-normal: 400;
+    --font-weight-medium: 500;
+    --font-weight-semibold: 600;
+    --font-weight-bold: 700;
+
+    --letter-spacing-tight: -0.01em;
+    --letter-spacing-normal: 0em;
+    --letter-spacing-wide: 0.08em;
+    --letter-spacing-wider: 0.12em;
+    --letter-spacing-widest: 0.18em;
+
+    --line-height-tight: 1.2;
+    --line-height-snug: 1.375;
+    --line-height-normal: 1.5;
+    --line-height-relaxed: 1.75;
+
+    /* ── Shadows ────────────────────────────────────────────────── */
+    --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+    --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.08), 0 2px 4px -2px rgb(0 0 0 / 0.04);
+    --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.08), 0 4px 6px -4px rgb(0 0 0 / 0.04);
+
+    /* ── Transitions ────────────────────────────────────────────── */
+    --transition-fast: 150ms ease;
+    --transition-base: 200ms ease;
+    --transition-slow: 300ms ease;
   }
 {% endstyle %}


### PR DESCRIPTION
Extracted design tokens from the Vintage Tub & Bath screenshot and applied them across the three foundational theme files:

config/settings_data.json
- Set type_primary_font: work_sans_n4
- Set max_page_width: 110rem (wide layout)
- Set background_color: #ffffff, foreground_color: #2d2d2d
- Set input_corner_radius: 0 (rectangular inputs per brand style)

snippets/css-variables.liquid
- Retained all original font/layout/color mappings
- Added extended CSS custom properties: • Surface palette (primary #fff, secondary #f9fafb, tertiary #f3f4f6) • Header/nav colors (dark navy #1a2332 announcement bar, white nav) • Primary button tokens (dark fill #2d2d2d + white text) • Secondary/outline button tokens (transparent + dark border) • Text hierarchy (primary, secondary, muted, inverted) • Border tokens (light #e5e7eb, strong #d1d5db) • Feedback tokens (sale red #c0392b, star amber #f5a623, badges) • Footer palette (dark slate #2c3748, light text) • Promo bar palette • Border-radius tokens for buttons (0px) and cards (0px) • 8-step spacing scale • Typography scale (font sizes, weights, letter-spacing, line-height) • Shadow scale (sm/md/lg) • Transition speed tokens

assets/critical.css
- Wired new tokens into base body, heading, link styles
- Added .section-heading utility (uppercase, wide letter-spacing)
- Added .btn, .btn--primary, .btn--secondary component classes
- Added focused input styles using border tokens
- Added .card, .badge (--new / --sale), .price (--sale / --compare)
- Added .star-rating and hr divider using border tokens

https://claude.ai/code/session_01UqChF1EyNyz8UsNoV11Fhh