### PR TITLE
Cart link label

### DIFF
--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -16,7 +16,10 @@
       </shopify-account>
     {% endif %}
 
-    <a href="{{ routes.cart_url }}">
+    <a
+      href="{{ routes.cart_url }}"
+      aria-label="{{ 'cart.title' | t }} {% if cart.item_count > 0 %}({{ cart.item_count }}){% endif %}"
+    >
       {% if cart.item_count > 0 %}
         <sup>{{ cart.item_count }}</sup>
       {% endif %}


### PR DESCRIPTION
👋 This PR adds an `aria-label` to the Cart link. This helps to provide a purpose for the link during screen reader navigation and discovery. It also adds the item count to the label as `aria-label` overrides any text content within.

Tested using Shopify CLI `shopify theme dev` env with Chrome+ChromeVox screen reader.

This change satisfies WCAG [2.4.4 Link Purpose (In Context)](https://www.w3.org/WAI/WCAG22/Understanding/link-purpose-in-context.html) Level A.