### PR TITLE
Cart quantity label

### DIFF
--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -17,7 +17,8 @@
     "checkout": "Checkout",
     "title": "Cart",
     "update": "Update",
-    "remove": "Remove"
+    "remove": "Remove",
+    "quantity": "Quantity for {{ title }}"
   },
   "customers": {
     "login": {

--- a/sections/cart.liquid
+++ b/sections/cart.liquid
@@ -19,7 +19,12 @@
           {{ 'cart.remove' | t | link_to: item.url_to_remove }}
         </td>
         <td>
-          <input type="text" name="updates[]" value="{{ item.quantity }}">
+          <input
+            type="text"
+            name="updates[]"
+            value="{{ item.quantity }}"
+            aria-label="{{ 'cart.quantity' | t: title: item.product.title }}"
+          >
           <input type="submit" value="{{ 'cart.update' | t }}">
         </td>
       </tr>


### PR DESCRIPTION
👋 This PR adds an `aria-label` to the quantity `input` on the Cart page. This helps to provide a purpose for the `input` during screen reader navigation and discovery. It also adds the item title to provide a unique label for large carts.

Tested using Shopify CLI `shopify theme dev` env with Chrome+ChromeVox screen reader.

This change satisfies WCAG [3.3.2 Labels or Instructions](https://www.w3.org/WAI/WCAG22/Understanding/labels-or-instructions.html) Level A.