### PR TITLE
Product labels

### DIFF
--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -42,6 +42,11 @@
     "password": "Password",
     "enter": "Enter"
   },
+  "product": {
+    "add_to_cart": "Add to cart",
+    "quantity": "Quantity",
+    "variant": "Variant"
+  },
   "search": {
     "title": "Search",
     "placeholder": "Search articles, pages, or products",

--- a/sections/product.liquid
+++ b/sections/product.liquid
@@ -21,7 +21,7 @@
   {% form 'product', product %}
     {% assign current_variant = product.selected_or_first_available_variant %}
 
-    <select name="id">
+    <select name="id" aria-label="{{ 'product.variant' | t }}">
       {% for variant in product.variants %}
         <option
           value="{{ variant.id }}"
@@ -34,9 +34,9 @@
       {% endfor %}
     </select>
 
-    <input type="text" name="quantity" min="1" value="1">
+    <input type="text" name="quantity" min="1" value="1" aria-label="{{ 'product.quantity' | t }}">
 
-    <input type="submit" value="Add to cart">
+    <input type="submit" value="{{ 'product.add_to_cart' | t }}">
     {{ form | payment_button }}
   {% endform %}
 </div>


### PR DESCRIPTION
👋 This PR adds an `aria-label` to the variant and quantity `input` elements on the Product page. This helps to provide a purpose for the `input` during screen reader navigation and discovery. It also adds a new translation for the hard-coded "Add to cart" string.

Tested using Shopify CLI `shopify theme dev` env with Chrome+ChromeVox screen reader.

This change satisfies WCAG [3.3.2 Labels or Instructions](https://www.w3.org/WAI/WCAG22/Understanding/labels-or-instructions.html) Level A.