### PR TITLE
Add image alt

### DIFF
--- a/sections/cart.liquid
+++ b/sections/cart.liquid
@@ -12,7 +12,7 @@
     {% for item in cart.items %}
       <tr>
         <td>
-          {% render 'image', image: item.image, url: item.url %}
+          {% render 'image', image: item.image, url: item.url, alt: item.image.alt %}
         </td>
         <td>
           <p>{{ item.product.title }}</p>

--- a/sections/collection.liquid
+++ b/sections/collection.liquid
@@ -18,7 +18,8 @@
             url: product.url,
             width: 400,
             height: 400,
-            crop: 'center'
+            crop: 'center',
+            alt: product.featured_image.alt
           %}
         {% endif %}
         <div class="collection-product__content">

--- a/sections/collections.liquid
+++ b/sections/collections.liquid
@@ -19,7 +19,8 @@
           image: collection.featured_image,
           width: 600,
           height: 600,
-          crop: 'center'
+          crop: 'center',
+          alt: ''
         %}
       {% endif %}
 

--- a/sections/hello-world.liquid
+++ b/sections/hello-world.liquid
@@ -18,7 +18,7 @@
       </p>
     </div>
     <div class="icon">
-      <img src="{{ 'shoppy-x-ray.svg' | asset_url }}" width="300" height="300">
+      <img src="{{ 'shoppy-x-ray.svg' | asset_url }}" width="300" height="300" alt="">
     </div>
   </div>
 </div>

--- a/sections/product.liquid
+++ b/sections/product.liquid
@@ -7,7 +7,7 @@
 
 <div class="product-images">
   {% for image in product.images %}
-    {% render 'image', class: 'product-image', image: image %}
+    {% render 'image', class: 'product-image', image: image, alt: image.alt %}
   {% endfor %}
 </div>
 

--- a/sections/search.liquid
+++ b/sections/search.liquid
@@ -31,7 +31,13 @@
           <div class="search-result">
             {% assign featured_image = result.featured_image | default: result.image %}
             {% if featured_image %}
-              {% render 'image', class: 'search-result__image', image: featured_image, url: result.url, width: 400 %}
+              {% render 'image',
+                class: 'search-result__image',
+                image: featured_image,
+                url: result.url,
+                width: 400,
+                alt: featured_image.alt
+              %}
             {% endif %}
             <div class="search-result__content">
               <p>

--- a/snippets/image.liquid
+++ b/snippets/image.liquid
@@ -13,6 +13,7 @@
   @param {number} [width] - The highest resolution width of the image to be rendered
   @param {number} [height] - The highest resolution height of the image to be rendered
   @param {string} [crop] - The crop position of the image
+  @param {string} [alt] - The image description
 
   @example
   {% render 'image', image: product.featured_image %}
@@ -24,6 +25,7 @@
     width: 1200,
     height: 800,
     crop: 'center',
+    alt: product.featured_image.alt
   %}
 {% enddoc %}
 
@@ -45,7 +47,7 @@
     href="{{ url }}"
   {% endif %}
 >
-  {{ image | image_url: width: width, height: height, crop: crop | image_tag }}
+  {{ image | image_url: width: width, height: height, crop: crop | image_tag: alt: alt }}
 </{{ wrapper }}>
 
 {% stylesheet %}


### PR DESCRIPTION
👋 This PR adds image `alt` attributes throughout with appropriate values. This helps to provide image descriptions for images during screen reader navigation and discovery.

- Adds empty `alt` attr on the homepage, setting as decorative
- Removes `alt` values on collection pages, settings as decorative
- Adds product `alt` attr and values on search, product listing, product description, and cart pages

Tested using Shopify CLI `shopify theme dev` env with Chrome+ChromeVox screen reader.

This change satisfies WCAG [1.1.1 Non-text Content](https://www.w3.org/WAI/WCAG22/Understanding/non-text-content.html) Level A.