### PR TITLE
Add search label

### DIFF
--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -44,6 +44,7 @@
   },
   "search": {
     "title": "Search",
+    "search": "Search",
     "placeholder": "Search articles, pages, or products",
     "submit": "Search",
     "no_results_html": "No results found for {{ terms }}",

--- a/sections/search.liquid
+++ b/sections/search.liquid
@@ -14,6 +14,7 @@
     name="q"
     value="{{ search.terms | escape }}"
     placeholder="{{ 'search.placeholder' | t }}"
+    aria-label="{{ 'search.search' | t }}"
   >
   <button type="submit">{{ 'search.submit' | t }}</button>
 </form>


### PR DESCRIPTION
👋 This PR adds an `aria-label` to the search `input` on the Search page. This helps to provide a purpose for the `input` during screen reader navigation and discovery.

Tested using Shopify CLI `shopify theme dev` env with Chrome+ChromeVox screen reader.

This change satisfies WCAG [3.3.2 Labels or Instructions](https://www.w3.org/WAI/WCAG22/Understanding/labels-or-instructions.html) Level A.