### PR TITLE
Skip link

### DIFF
--- a/assets/critical.css
+++ b/assets/critical.css
@@ -97,7 +97,8 @@ body {
     calc(100% - var(--page-margin) * 2)
   );
   --content-margin: minmax(var(--page-margin), 1fr);
-  --content-grid: var(--content-margin) var(--content-width) var(--content-margin);
+  --content-grid: var(--content-margin) var(--content-width)
+    var(--content-margin);
 
   /* This is required to make <img> elements work as background images */
   position: relative;
@@ -114,4 +115,14 @@ body {
 /* Child elements that use the full-width utility class span the entire viewport. */
 .shopify-section > .full-width {
   grid-column: 1 / -1;
+}
+
+/* Visually hide content while keeping it available in the accessibility tree. */
+.visually-hidden:not(:focus):not(:active) {
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
 }

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -29,7 +29,9 @@
   <body>
     {% sections 'header-group' %}
 
-    {{ content_for_layout }}
+    <main id="main" tabindex="-1">
+      {{ content_for_layout }}
+    </main>
 
     {% sections 'footer-group' %}
   </body>

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -30,6 +30,9 @@
   "collections": {
     "title": "Collections"
   },
+  "general": {
+    "skip_link": "Skip to main content"
+  },
   "gift_card": {
     "add_to_apple_wallet": "Add to Apple Wallet",
     "card": "Gift card",
@@ -37,6 +40,7 @@
     "expires_on": "Expires on {{ expires_on }}",
     "use_at_checkout": "Use this gift card at checkout"
   },
+
   "password": {
     "title": "This shop is private",
     "password": "Password",

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -40,7 +40,6 @@
     "expires_on": "Expires on {{ expires_on }}",
     "use_at_checkout": "Use this gift card at checkout"
   },
-
   "password": {
     "title": "This shop is private",
     "password": "Password",

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -1,4 +1,8 @@
 <header>
+  <a href="#main" class="skip-link visually-hidden">
+    {{ 'general.skip_link' | t }}
+  </a>
+
   <h2 class="header__title">
     {{ shop.name | link_to: routes.root_url }}
   </h2>
@@ -54,6 +58,14 @@
   header .header__icons {
     display: flex;
     gap: 1rem;
+  }
+
+  header .skip-link {
+    position: absolute;
+    top: 0;
+    left: 0;
+    padding: var(--page-margin);
+    background-color: var(--color-background);
   }
 {% endstylesheet %}
 


### PR DESCRIPTION
👋 This PR adds a global "skip link" to header of all pages. This helps to provide a consistent method for keyboard-only users to bypass common content such as header navigation. It also adds a `main` element to provide a main landmark for screen readers.

Tested using Shopify CLI `shopify theme dev` env with Chrome+ChromeVox screen reader.

This change satisfies WCAG [2.4.1 Bypass Blocks](https://www.w3.org/WAI/WCAG22/Understanding/bypass-blocks.html) Level A.