### PR TITLE
Fix trailing comma in JSON schema formatting

### DIFF
--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -72,6 +72,6 @@
       "title": "Title",
       "subtitle": "Subtitle",
       "normal": "Normal text"
-    },
+    }
   }
 }


### PR DESCRIPTION
There's a trailing comma after the "text_style" object in the options section.