### PR TITLE
Fix trailing comma in en.default.schema.json

### DIFF
--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -72,6 +72,6 @@
       "title": "Title",
       "subtitle": "Subtitle",
       "normal": "Normal text"
-    },
+    }
   }
 }


### PR DESCRIPTION
## What
Removes a trailing comma after the `text_style` object in `locales/en.default.schema.json` that makes the file invalid JSON.

## Why
Strict JSON parsers (e.g. `JSON.parse`, Python's `json`) reject the file as shipped, which breaks translation tooling and any pipeline that round-trips locale files. Shopify's own parser tolerates it, so the bug is silent in the editor but surfaces the moment the file is processed externally.

```
$ python3 -c "import json; json.load(open('locales/en.default.schema.json'))"
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 76 column 3
```

## Change
One character: `},` → `}` on line 75. All other locale files already parse cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)